### PR TITLE
fix: use :focus-visible polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "neutralinojs-svelte",
-  "version": "0.1.0",
+  "name": "emojitinypicker",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2991,6 +2991,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "follow-redirects": {
       "version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "webpack-dev-server": "^3.3.1"
   },
   "dependencies": {
-    "emoji-picker-element": "^1.0.3"
+    "emoji-picker-element": "^1.0.3",
+    "focus-visible": "^5.2.0"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,13 @@
 <script>
     import Picker from 'emoji-picker-element/svelte'
+    import supportsSelector from './supportsSelector'
+
+    const supportsFocusVisible = supportsSelector(':focus-visible')
+
+    if (!supportsFocusVisible) {
+        // only apply the :focus-visible polyfill if it's unsupported
+        require('focus-visible/dist/focus-visible.min.js');
+    }
 
     const picker = new Picker();
     picker.dataSource = './assets/emojilist.js';
@@ -14,6 +22,13 @@
         pickemoji = (event.detail.emoji.unicode);
         document.querySelector('input').value += pickemoji;
     });
+
+    (async () => {
+        if (!supportsFocusVisible) {
+            applyFocusVisiblePolyfill(picker.shadowRoot);
+        }
+    })();
+
     function copyBtn() {
         var copyText = document.getElementById("emojis");
         copyText.select();

--- a/src/supportsSelector.js
+++ b/src/supportsSelector.js
@@ -1,0 +1,13 @@
+// See https://stackoverflow.com/a/8533927
+export default function supportsSelector (selector) {
+  const style = document.createElement('style');
+  document.head.appendChild(style);
+  try {
+    style.sheet.insertRule(selector + '{}', 0);
+  } catch (e) {
+    return false;
+  } finally {
+    document.head.removeChild(style);
+  }
+  return true;
+}


### PR DESCRIPTION
This PR uses the [focus-visible](https://github.com/WICG/focus-visible) polyfill to improve the focus styles. The gray focus box is shown for keyboard users, but not mouse users, as shown in [this video](https://gfycat.com/slushytestyhectorsdolphin).

AFAICT Neutralino requires the polyfill for all platforms except (maybe?) Windows, where I imagine it's using the Chromium Edge engine under the hood. I only tested on Ubuntu, where I definitely can see the difference. See details on [caniuse](https://caniuse.com/css-focus-visible).